### PR TITLE
Update mopidy-party ext with Python 3 support

### DIFF
--- a/_ext/party.md
+++ b/_ext/party.md
@@ -5,7 +5,7 @@ dev:
   github: Lesterpig/mopidy-party
 dist:
   pypi: Mopidy-Party
-py3: false
+py3: true
 images:
   - /media/ext/party.jpg
 ---


### PR DESCRIPTION
New version 1.0.0 now supports Python 3, thanks for helping me on this issue :)