### PR TITLE
add Fedora/RPMFusion packages

### DIFF
--- a/_ext/mpd.md
+++ b/_ext/mpd.md
@@ -10,6 +10,7 @@ dist:
   apt-debian: mopidy-mpd
   apt-mopidy: mopidy-mpd
   arch-aur: mopidy-mpd
+  fedora: mopidy-mpd
   homebrew:
     tap: mopidy/mopidy
     formula: mopidy-mpd

--- a/_ext/spotify.md
+++ b/_ext/spotify.md
@@ -11,6 +11,7 @@ dist:
   pypi: Mopidy-Spotify
   apt-mopidy: mopidy-spotify
   arch-aur: mopidy-spotify
+  rpmfusion: nonfree/mopidy-spotify
   homebrew:
     tap: mopidy/mopidy
     formula: mopidy-spotify

--- a/_layouts/ext.html
+++ b/_layouts/ext.html
@@ -122,6 +122,14 @@ layout: default
                     </a>
                   </li>
                 {% endif %}
+                {% if ext.dist.fedora or ext.dist.rpmfusion %}
+                  <li>
+                    <a href="#fedora">
+                      <span class="icon"><img src="https://unpkg.com/simple-icons@latest/icons/fedora.svg" /></span>
+                      <span>Fedora</span>
+                    </a>
+                  </li>
+                {% endif %}
                 {% if ext.dist.homebrew %}
                   <li>
                     <a href="#macos">
@@ -194,6 +202,27 @@ layout: default
                 <a href="https://aur.archlinux.org/packages/{{ ext.dist.arch-aur }}">AUR</a>:
               </p>
               <pre class="select copy">yay -S {{ ext.dist.arch-aur }}</pre>
+            </div>
+          {% endif %}
+
+          {% if ext.dist.fedora %}
+            <div class="tab-content is-hidden" id="fedora">
+              <p>
+		Install the <code>{{ ext.dist.fedora }}</code> package from
+                <a href="https://src.fedoraproject.org/rpms/{{ ext.dist.fedora }}">Fedora</a>:
+              </p>
+              <pre class="select copy">dnf install {{ ext.dist.fedora }}</pre>
+            </div>
+          {% endif %}
+
+          {% if ext.dist.rpmfusion %}
+            {% assign parts = ext.dist.rpmfusion | split: '/' %}
+            <div class="tab-content is-hidden" id="fedora">
+              <p>
+		Install the <code>{{ parts | shift }}</code> package from
+                <a href="https://admin.rpmfusion.org/pkgdb/package/{{ ext.dist.rpmfusion }}">RPMFusion-{{ parts | pop }}</a>:
+              </p>
+              <pre class="select copy">dnf install {{ parts | shift }}</pre>
             </div>
           {% endif %}
 

--- a/ext/dists.html
+++ b/ext/dists.html
@@ -27,6 +27,7 @@ title: Extension distributions
             <th class="has-text-centered">APT (Debian)</th>
             <th class="has-text-centered">APT (Mopidy)</th>
             <th class="has-text-centered">Arch (AUR)</th>
+            <th class="has-text-centered">Fedora / RPMFusion</th>
             <th class="has-text-centered">macOS</th>
           </tr>
         </thead>
@@ -76,6 +77,23 @@ title: Extension distributions
                 {% if ext.dist.bundled %}
                   <a href="https://www.archlinux.org/packages/community/any/mopidy/" title="Arch Linux (Community)">
                     <span class="icon"><img src="https://unpkg.com/simple-icons@latest/icons/archlinux.svg" /></span>
+                  </a>
+                {% endif %}
+              </td>
+              <td class="has-text-centered">
+                {% if ext.dist.fedora %}
+                  <a href="https://src.fedoraproject.org/rpms/{{ ext.dist.fedora }}/" title="Fedora">
+                    <span class="icon"><img src="https://unpkg.com/simple-icons@latest/icons/fedora.svg" /></span>
+                  </a>
+                {% elsif ext.dist.rpmfusion %}
+                  {% assign parts = ext.dist.rpmfusion | split: '/' %}
+                  <a href="https://admin.rpmfusion.org/pkgdb/packages/{{ ext.dist.rpmfusion }}/" title="RPMFusion ({{ parts | pop }})">
+                    <span class="icon"><img src="https://unpkg.com/simple-icons@latest/icons/fedora.svg" />*</span>
+                  </a>
+                {% endif %}
+                {% if ext.dist.bundled %}
+                  <a href="https://src.fedoraproject.org/rpms/mopidy/" title="Fedora">
+                    <span class="icon"><img src="https://unpkg.com/simple-icons@latest/icons/fedora.svg" /></span>
                   </a>
                 {% endif %}
               </td>


### PR DESCRIPTION
co-PR to mopidy#1881

There isn't an RPMFusion logo in the icon library, so I've used the Fedora logo with an asterisk for the /ext/dists/ page. Happy to change anything you want me to.