### PR TITLE
Fix links of pypi project stats

### DIFF
--- a/_includes/ext-stats.html
+++ b/_includes/ext-stats.html
@@ -23,7 +23,7 @@
           </a>
         {% endif %}
         {% if ext.dist.pypi %}
-          <a href="https://pypi.org/ext/{{ ext.dist.pypi }}">
+          <a href="https://pypi.org/project/{{ ext.dist.pypi }}">
             <img
               alt="PyPI - Downloads"
               src="https://img.shields.io/pypi/dm/{{ ext.dist.pypi }}?label=PyPI%20downloads&amp;style=flat-square"
@@ -36,13 +36,13 @@
     {% if ext.dist.pypi %}
       <h5 class="is-size-7 is-uppercase has-text-grey">PyPI</h5>
       <p>
-        <a href="https://pypi.org/ext/{{ ext.dist.pypi }}">
+        <a href="https://pypi.org/project/{{ ext.dist.pypi }}">
           <img
             alt="PyPI - Package version"
             src="https://img.shields.io/pypi/v/{{ ext.dist.pypi }}?label=Package%20version&amp;style=flat-square"
           />
         </a>
-        <a href="https://pypi.org/ext/{{ ext.dist.pypi }}">
+        <a href="https://pypi.org/project/{{ ext.dist.pypi }}">
           <img
             alt="PyPI - Python support"
             src="https://img.shields.io/pypi/pyversions/{{ ext.dist.pypi }}?label=Python%20support&amp;style=flat-square"
@@ -54,7 +54,7 @@
     {% if ext.dist.pypi %}
       <h5 class="is-size-7 is-uppercase has-text-grey">License</h5>
       <p>
-        <a href="https://pypi.org/ext/{{ ext.dist.pypi }}">
+        <a href="https://pypi.org/project/{{ ext.dist.pypi }}">
           <img
             alt="PyPI - License"
             src="https://img.shields.io/pypi/l/{{ ext.dist.pypi }}?label=&amp;style=flat-square"


### PR DESCRIPTION
Along the stats on the side of each extension page (Downloads, version, license, etc) currently the links go to `https://pypi.org/ext/$project-name`, which leads to a 404.  This corrects it to `https://pypi.org/project/$project-name`