### PR TITLE
Change to mention the plugin use the API

### DIFF
--- a/_ext/subidy.md
+++ b/_ext/subidy.md
@@ -11,4 +11,13 @@ dist:
 ---
 
 A backend for playing music from a
-[Subsonic Music Streamer](https://www.subsonic.org/) library.
+[Subsonic API enabled Server ](http://www.subsonic.org/pages/api.jsp) library.
+
+Some of the solutions who provide Subsonic API support are:
+[Subsonic](http://www.subsonic.org)
+[Airsonic](https://github.com/airsonic/airsonic)
+[Navidrome](https://github.com/deluan/navidrome)
+[Funkwhale](https://funkwhale.audio/) - Funkwhale also have his own Mopidy extension provided by themselves
+
+
+


### PR DESCRIPTION
The fact it uses API means many servers can be used as soon as they provide the support for it.