### PR TITLE
Add existing funkwhale plugin

### DIFF
--- a/_ext/funkwhale.md
+++ b/_ext/funkwhale.md
@@ -1,0 +1,14 @@
+---
+title: mopidy-funkwhale
+type: backend
+dev:
+  gitlab: https://dev.funkwhale.audio/funkwhale/mopidy/
+  circleci: true
+  codecov: true
+dist:
+  arch-aur: mopidy-funkwhale
+  pypi: mopidy-funkwhale
+---
+
+A backend for playing music from a
+[Funkwhale Server](https://https://funkwhale.audio/) library.

--- a/_ext/funkwhale.md
+++ b/_ext/funkwhale.md
@@ -11,4 +11,4 @@ dist:
 ---
 
 A backend for playing music from a
-[Funkwhale Server](https://https://funkwhale.audio/) library.
+[Funkwhale Server](https://funkwhale.audio/) library.

--- a/_ext/funkwhale.md
+++ b/_ext/funkwhale.md
@@ -3,8 +3,6 @@ title: Mopidy-Funkwhale
 type: backend
 dev:
   gitlab: https://dev.funkwhale.audio/funkwhale/mopidy/
-  circleci: true
-  codecov: true
 dist:
   arch-aur: mopidy-funkwhale
   pypi: mopidy-funkwhale

--- a/_ext/funkwhale.md
+++ b/_ext/funkwhale.md
@@ -1,5 +1,5 @@
 ---
-title: mopidy-funkwhale
+title: Mopidy-Funkwhale
 type: backend
 dev:
   gitlab: https://dev.funkwhale.audio/funkwhale/mopidy/

--- a/_ext/funkwhale.md
+++ b/_ext/funkwhale.md
@@ -3,8 +3,6 @@ title: Mopidy-Funkwhale
 type: backend
 dev:
   gitlab: https://dev.funkwhale.audio/funkwhale/mopidy/
-dist:
-  arch-aur: mopidy-funkwhale
   pypi: mopidy-funkwhale
 ---
 


### PR DESCRIPTION
 While roaming around i saw there was an existing plugin for Funkwhale not mentioned in extensions:
Here it is.

I have actually no idea about thoses following informations: may you please check and correct accordingly?

gitlab: https://dev.funkwhale.audio/funkwhale/mopidy/
  circleci: true
  codecov: true
dist:
  arch-aur: mopidy-funkwhale
  pypi: mopidy-funkwhale

Regards  - JS