### PR TITLE
Create autoplay.md

### DIFF
--- a/_ext/autoplay.md
+++ b/_ext/autoplay.md
@@ -1,0 +1,16 @@
+---
+title: Mopidy-Autoplay
+type: frontend
+dev:
+  github: sphh/mopidy-autoplay
+dist:
+  pypi: Mopidy-Autoplay
+---
+
+Mopidy extension to automatically pick up where you left off and start playing
+the last track from the position before Mopidy was shut down. It also restores
+the tracklist options "Consume", "Random", "Repeat" and "Single". It also
+remembers the volume and if Mopidy was muted.
+
+The exact behaviour is configurable, e.g. it is possible to force Mopidy to
+play a certain track or to start always unmuted.


### PR DESCRIPTION
Hi, I wrote (and uploaded this new extension to PyPi), because I hated it from the beginning, that after switching on my Raspberry running Mopidy I had to start the computer, start the browser and head to Mopidy to start playing my favourite webradio.

I would appreciate, if you could add it to your list of extensions (or give me some comments about the implementation ;-) ). Thanks.