### PR TITLE
New extension: play public Spotify playlists using YouTube Music

### DIFF
--- a/_ext/spotitube.md
+++ b/_ext/spotitube.md
@@ -1,0 +1,8 @@
+title: Mopidy-SpotiTube
+type: backend
+
+dev:
+  github: natumbri/mopidy-spotitube
+
+service: Spotify, YouTube Music
+

--- a/_ext/spotitube.md
+++ b/_ext/spotitube.md
@@ -1,3 +1,4 @@
+---
 title: Mopidy-SpotiTube
 type: backend
 
@@ -6,3 +7,7 @@ dev:
 
 service: Spotify, YouTube Music
 
+---
+
+A backend for playing public [Spotify](https://www.spotify.com/) user playlists
+using the [mopidy-youtube](https://mopidy.com/ext/youtube/) extension.


### PR DESCRIPTION
New extension: play public Spotify playlists using YouTube Music.

Useful for me; might be useful for someone else.  Pretty beta, but seems to work ok.