### PR TITLE
Fix github url for Mopidy-Tidal extension

### DIFF
--- a/_ext/tidal.md
+++ b/_ext/tidal.md
@@ -4,7 +4,7 @@ service: Tidal
 logo: /media/ext/tidal.png
 type: backend
 dev:
-  github: https://github.com/tehkillerbee/mopidy-tidal
+  github: tehkillerbee/mopidy-tidal
   codecov: true
 dist:
   pypi: Mopidy-Tidal


### PR DESCRIPTION
* Removed github URL as it is prepended automatically.