### PR TITLE
Add Mopidy-Listenbrainz to extension registry

### DIFF
--- a/_ext/listenbrainz.md
+++ b/_ext/listenbrainz.md
@@ -8,5 +8,5 @@ dist:
 logo: /media/ext/listenbrainz.svg
 ---
 
-Extension for recording song listens to [Listenbrainz](https://listenbrainz.org), a libre alternative to
-Last.fm.  It also provides Listenbrainz-generated recommendation playlists to Mopidy.
+Extension for recording song listens to [ListenBrainz](https://listenbrainz.org), a libre alternative to
+Last.fm.  It also provides ListenBrainz-generated recommendation playlists to Mopidy.

--- a/_ext/listenbrainz.md
+++ b/_ext/listenbrainz.md
@@ -1,0 +1,12 @@
+---
+title: Mopidy-Listenbrainz
+type: frontend
+dev:
+  github: suaviloquence/mopidy-listenbrainz
+dist:
+  pypi: Mopidy-Listenbrainz
+logo: /media/ext/listenbrainz.svg
+---
+
+Extension for recording song listens to [Listenbrainz](https://listenbrainz.org), a libre alternative to
+Last.fm.  It also provides Listenbrainz-generated recommendation playlists to Mopidy.

--- a/media/ext/listenbrainz.svg
+++ b/media/ext/listenbrainz.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><svg id="a" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 30"><defs><style>.b{fill:#353070;}.c{fill:#eb743b;}</style></defs><polygon class="b" points="13 1 1 8 1 22 13 29 13 1"/><polygon class="c" points="14 1 26 8 26 22 14 29 14 1"/></svg>


### PR DESCRIPTION
For `type`, we provide both a backend (providing listenbrainz-generated playlists) and a frontend (recording listened-to tracks), so I chose frontend because that's the primary function, but we do have both, so if I should change it, let me know.  Thanks!
